### PR TITLE
Bug Fixes

### DIFF
--- a/BasketBall_LiveScore/Mappers/Impl/LiveScoreMappers.cs
+++ b/BasketBall_LiveScore/Mappers/Impl/LiveScoreMappers.cs
@@ -24,8 +24,8 @@ namespace BasketBall_LiveScore.Mappers.Impl
                 match.QuarterDuration,
                 match.NumberOfQuarters,
                 match.TimeOutDuration,
-                TeamMapper.ConvertToDto(match.Hosts),
                 TeamMapper.ConvertToDto(match.Visitors),
+                TeamMapper.ConvertToDto(match.Hosts),
                 match.HostsStartingPlayers.Select(player => player.Id)
                                           .Concat(match.VisitorsStartingPlayers.Select(player => player.Id))
                                           .ToList(),

--- a/BasketBall_LiveScore/Repositories/Impl/MatchRepository.cs
+++ b/BasketBall_LiveScore/Repositories/Impl/MatchRepository.cs
@@ -63,6 +63,8 @@ namespace BasketBall_LiveScore.Repositories.Impl
                     .ThenInclude(team => team.Players)
                 .Include(match => match.PrepEncoder)
                 .Include(match => match.PlayEncoders)
+                .Include(match => match.HostsStartingPlayers)
+                .Include(match => match.VisitorsStartingPlayers)
                 .AsAsyncEnumerable();
             await foreach (var match in matchs)
             {
@@ -81,6 +83,8 @@ namespace BasketBall_LiveScore.Repositories.Impl
                     .ThenInclude(team => team.Players)
                 .Include(match => match.PrepEncoder)
                 .Include(match => match.PlayEncoders)
+                .Include(match => match.HostsStartingPlayers)
+                .Include(match => match.VisitorsStartingPlayers)
                 .AsAsyncEnumerable();
             await foreach (var encoderMatch in encoderMatchs) { yield return encoderMatch; }
         }
@@ -94,6 +98,8 @@ namespace BasketBall_LiveScore.Repositories.Impl
                     .ThenInclude(team => team.Players)
                 .Include(match => match.PrepEncoder)
                 .Include(match => match.PlayEncoders)
+                .Include(match => match.HostsStartingPlayers)
+                .Include(match => match.VisitorsStartingPlayers)
                 .FirstOrDefaultAsync(m => m.Id.Equals(id));
             return match;
         }
@@ -108,6 +114,8 @@ namespace BasketBall_LiveScore.Repositories.Impl
                     .ThenInclude(team => team.Players)
                 .Include(match => match.PrepEncoder)
                 .Include(match => match.PlayEncoders)
+                .Include(match => match.HostsStartingPlayers)
+                .Include(match => match.VisitorsStartingPlayers)
                 .AsAsyncEnumerable();
             await foreach (var match in teamMatchs)
             {
@@ -125,6 +133,8 @@ namespace BasketBall_LiveScore.Repositories.Impl
                     .ThenInclude(team => team.Players)
                 .Include(match => match.PrepEncoder)
                 .Include(match => match.PlayEncoders)
+                .Include(match => match.HostsStartingPlayers)
+                .Include(match => match.VisitorsStartingPlayers)
                 .AsAsyncEnumerable();
             await foreach (var match in matchs) { yield return match; }
         }


### PR DESCRIPTION
BUG Fix : Wrong order in DTO conversion
BUG Fix : Forgotten Include statement in Match retrieval

## Explanation

In the DTO conversion, hosts and visitors were sent in their DTO conversion format in the wrong order, causing front end clients to mistakenly display and handle the teams under the wrong property names

A match field players were inaccessible before due to a missing include statement over the starting players (= field players) of both teams, causing them to prevent the computation of the field players. As a result, front end could not access the field players of a match nor perform any operation on it